### PR TITLE
Explain why invalid "I_..." example fails

### DIFF
--- a/source/reference/object.rst
+++ b/source/reference/object.rst
@@ -479,6 +479,7 @@ match either regular expression are forbidden.
     // If the name starts with ``S_``, it must be a string
     { "S_0": 42 }
     --X
+    // If the name starts with ``I_``, it must be an integer
     { "I_42": "This is a string" }
     --
     // This is a key that doesn't match any of the regular


### PR DESCRIPTION
The invalid "S_..." example has a simple explanation of why it fails. This adds a similar explanation to the invalid "I_..." example.