### PR TITLE
corrected validation

### DIFF
--- a/reference/object.html
+++ b/reference/object.html
@@ -594,7 +594,7 @@ match either regular expression are forbidden.</p>
 </div>
 <p class="jsonschema-comment">This is a key that doesn&#8217;t match any of the regular
 expressions:</p>
-<div class="jsonschema-pass highlight-javascript"><div class="highlight"><pre><span class="p">{</span> <span class="s2">&quot;keyword&quot;</span><span class="o">:</span> <span class="s2">&quot;value&quot;</span> <span class="p">}</span>
+<div class="jsonschema-fail highlight-javascript"><div class="highlight"><pre><span class="p">{</span> <span class="s2">&quot;keyword&quot;</span><span class="o">:</span> <span class="s2">&quot;value&quot;</span> <span class="p">}</span>
 </pre></div>
 </div>
 <p><code class="docutils literal"><span class="pre">patternProperties</span></code> can be used in conjunction with


### PR DESCRIPTION
It says that any additional properties that do not match either regular expression are forbbidden. The example doesnt use the "additionalProperties" keyword therefore it should pass {"keyword":"value"} as a valid property