### PR TITLE
Use actual unicode for the unicode example

### DIFF
--- a/source/reference/string.rst
+++ b/source/reference/string.rst
@@ -23,7 +23,7 @@ Unicode characters.
     "This is a string"
     --
     // Unicode characters:
-    "Déjà vu"
+    "json مخطط"
     --
     ""
     --


### PR DESCRIPTION
é and à are in the ASCII tables, so they don't really demonstrate
unicode. Used the arabic word for "schema" instead.
