### PR TITLE
Fix mixed content error

### DIFF
--- a/source/_static/jsonschema.css
+++ b/source/_static/jsonschema.css
@@ -1,5 +1,5 @@
 @import url(https://fonts.googleapis.com/css?family=Overlock:900);
-@import url(http://fonts.googleapis.com/css?family=Inconsolata);
+@import url(https://fonts.googleapis.com/css?family=Inconsolata);
 
 div.admonition {
     margin-top: 0;


### PR DESCRIPTION
At the moment, Chrome doesn't load the 'Inconsolata' font, because it is requested over HTTP.

![image](https://cloud.githubusercontent.com/assets/1307291/21359117/7334198c-c6db-11e6-93eb-9b58a92f3129.png)

![image](https://cloud.githubusercontent.com/assets/1307291/21359131/788146f8-c6db-11e6-84d8-0988ff7a7a14.png)


>Mixed Content: The page at 'https://spacetelescope.github.io/understanding-json-schema/structuring.html' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Inconsolata'. This request has been blocked; the content must be served over HTTPS