### PR TITLE
Lookahead

### DIFF
--- a/source/reference/regular_expressions.rst
+++ b/source/reference/regular_expressions.rst
@@ -48,6 +48,8 @@ syntax described below.
   all greedy; they match as much text as possible. Sometimes this
   behavior isn't desired and you want to match as few characters as
   possible.
+  
+- ``(?!x}``, ``(?=x}``: Negative and positive lookahead.
 
 - ``{x}``: Match exactly ``x`` occurrences of the preceding regular
   expression.


### PR DESCRIPTION
Both ECMA-262 and python support negative and positive lookahead.